### PR TITLE
prevent stream reader to initialize mutliple times

### DIFF
--- a/yajsapi/index.ts
+++ b/yajsapi/index.ts
@@ -6,8 +6,4 @@ import * as rest from "./rest";
 import * as storage from "./storage";
 import * as utils from "./utils";
 
-// "Warning: Possible EventEmitter memory leak detected. 11 wakeup listeners added. Use emitter.setMaxListeners() to increase limit"
-// Temp fix for the warning above, need to debug emitter and remove events, mostly causes from stringio
-events.EventEmitter.prototype.setMaxListeners(250);
-
 export { Engine, Task, vm, WorkContext, props, rest, storage, utils };

--- a/yajsapi/storage/index.ts
+++ b/yajsapi/storage/index.ts
@@ -49,7 +49,7 @@ export class Destination {
     });
 
     await new Promise(async (fulfill) => {
-      writableStream.on("finish", fulfill);
+      writableStream.once("finish", fulfill);
       for await (let chunk of content.stream) {
         writableStream.write(chunk);
       }
@@ -82,7 +82,7 @@ export class InputStorageProvider {
         highWaterMark: _BUF_SIZE,
         encoding: "binary",
       });
-      stream.on("end", () => {
+      stream.once("end", () => {
         stream.destroy();
       })
       for await (let chunk of stream) {


### PR DESCRIPTION
Resolves golemfactory/yagna-integration#288. as it solves last piece of the requirement list.
- Keep event emitter clear