### PR TITLE
Command output logs & getExecBatchResults timeout fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yajsapi",
-  "version": "0.3.0-alpha.7",
+  "version": "0.3.0-alpha.8",
   "description": "NodeJS API for Next Golem",
   "repository": "https://github.com/golemfactory/yajsapi",
   "main": "dist/index.js",

--- a/yajsapi/rest/activity.ts
+++ b/yajsapi/rest/activity.ts
@@ -424,11 +424,16 @@ class PollingBatch extends Batch {
       try {
         let { data } = await this.api.getExecBatchResults(
           this.activity_id,
-          this.batch_id
+          this.batch_id,
+          undefined,
+          { timeout: 5000 }
         );
         results = data;
       } catch (error) {
+        const timeout_msg = error.message && error.message.includes("timeout");
         if (error.response && error.response.status === 408) {
+          continue;
+        } else if (error.code === "ETIMEDOUT" || (error.code === "ECONNABORTED" && timeout_msg)) {
           continue;
         } else {
           if (error.response && error.response.status == 500 && error.response.data) {

--- a/yajsapi/rest/activity.ts
+++ b/yajsapi/rest/activity.ts
@@ -424,9 +424,7 @@ class PollingBatch extends Batch {
       try {
         let { data } = await this.api.getExecBatchResults(
           this.activity_id,
-          this.batch_id,
-          undefined,
-          { params: { timeout: 5 } }
+          this.batch_id
         );
         results = data;
       } catch (error) {

--- a/yajsapi/utils/log.ts
+++ b/yajsapi/utils/log.ts
@@ -237,7 +237,7 @@ class SummaryLogger {
         logger.silly(`Command ${cmd}: stdout: ${event["stdout"]}, stderr: ${event["stderr"]}, msg: ${event["message"]}.`);
       } else {
         logger.warn(`Command failed on provider '${provider_name}', command: ${cmd}, msg: ${event["message"]}`);
-        logger.silly(`Command ${cmd}: stdout: ${event["stdout"]}, stderr: ${event["stderr"]}.`);
+        logger.debug(`Command ${cmd}: stdout: ${event["stdout"]}, stderr: ${event["stderr"]}.`);
       }
     } else if (eventName === events.ScriptFinished.name) {
       const provider_info = this.agreement_provider_info[event["agr_id"]];

--- a/yajsapi/utils/log.ts
+++ b/yajsapi/utils/log.ts
@@ -231,18 +231,13 @@ class SummaryLogger {
       );
     } else if (eventName === events.CommandExecuted.name) {
       const provider_name = this.agreement_provider_info[event["agr_id"]].name;
+      const cmd = JSON.stringify(event["command"]);
       if (event["success"]) {
-        logger.debug(
-          `Command successful on provider '${provider_name}', command: ${JSON.stringify(
-            event["command"]
-          )}.`
-        );
+        logger.debug(`Command successful on provider '${provider_name}', command: ${cmd}.`);
+        logger.silly(`Command ${cmd}: stdout: ${event["stdout"]}, stderr: ${event["stderr"]}, msg: ${event["message"]}.`);
       } else {
-        logger.warn(
-          `Command failed on provider '${provider_name}', command: ${JSON.stringify(
-            event["command"]
-          )}, output: ${event["message"]}`
-        );
+        logger.warn(`Command failed on provider '${provider_name}', command: ${cmd}, msg: ${event["message"]}`);
+        logger.silly(`Command ${cmd}: stdout: ${event["stdout"]}, stderr: ${event["stderr"]}.`);
       }
     } else if (eventName === events.ScriptFinished.name) {
       const provider_info = this.agreement_provider_info[event["agr_id"]];
@@ -353,22 +348,21 @@ export function logSummary(
 
 export const changeLogLevel = (level: string) => {
   options.level = level;
-  options.transports.push(
+  options.transports = [
+    new winston.transports.Console({ level: level }),
     new winston.transports.File({
       filename: path.join(
         "logs",
         `yajsapi-${dayjs().format("YYYY-MM-DD_HH-mm-ss")}.log`
       ),
-      level: "debug",
-    }) as any
-  );
-  options.transports.push(
+      level: "silly",
+    }) as any,
     new winston.transports.File({
       filename: path.join("logs", "yajsapi-current.log"),
-      level: "debug",
+      level: "silly",
       options: { flags: "w" },
     }) as any
-  );
+  ];
   logger.configure(options);
 };
 


### PR DESCRIPTION
No changes when `-d` is not specified.
When it's specified, all command output (stdout and stderr) is appended to the log file. If a given command fails on a provider, its output is additionally printed to the console.