### PR TITLE
Add computation price caps

### DIFF
--- a/yajsapi/executor/index.ts
+++ b/yajsapi/executor/index.ts
@@ -183,8 +183,10 @@ export class Executor implements ComputationHistory {
     this._budget_amount = parseFloat(budget);
     this._strategy = strategy || new DecreaseScoreForUnconfirmedAgreement(
       new LeastExpensiveLinearPayuMS(
-        60,
-        new ComLinear(1.0, { [Counter.TIME]: 1.0, [Counter.CPU]: 1.0 })
+        60, 1.0, new Map([
+          [Counter.TIME, 1.0],
+          [Counter.CPU, 1.0]
+        ]),
       ),
       0.5
     );

--- a/yajsapi/executor/index.ts
+++ b/yajsapi/executor/index.ts
@@ -184,8 +184,8 @@ export class Executor implements ComputationHistory {
     this._strategy = strategy || new DecreaseScoreForUnconfirmedAgreement(
       new LeastExpensiveLinearPayuMS(
         60, 1.0, new Map([
-          [Counter.TIME, 1.0],
-          [Counter.CPU, 1.0]
+          [Counter.TIME, 0.1],
+          [Counter.CPU, 0.2]
         ]),
       ),
       0.5

--- a/yajsapi/executor/index.ts
+++ b/yajsapi/executor/index.ts
@@ -7,7 +7,7 @@ import { MarketDecoration } from "ya-ts-client/dist/ya-payment/src/models";
 import { WorkContext, Work, CommandContainer } from "./ctx";
 import * as events from "./events";
 import { Activity, NodeInfo, NodeInfoKeys } from "../props";
-import { ComLinear, Counter } from "../props/com";
+import { Counter } from "../props/com";
 import { DemandBuilder } from "../props/builder";
 
 import * as rest from "../rest";

--- a/yajsapi/executor/index.ts
+++ b/yajsapi/executor/index.ts
@@ -7,6 +7,7 @@ import { MarketDecoration } from "ya-ts-client/dist/ya-payment/src/models";
 import { WorkContext, Work, CommandContainer } from "./ctx";
 import * as events from "./events";
 import { Activity, NodeInfo, NodeInfoKeys } from "../props";
+import { ComLinear, Counter } from "../props/com";
 import { DemandBuilder } from "../props/builder";
 
 import * as rest from "../rest";
@@ -174,14 +175,19 @@ export class Executor implements ComputationHistory {
     this._driver = driver ? driver.toLowerCase() : DEFAULT_DRIVER;
     this._network = network ? network.toLowerCase() : DEFAULT_NETWORK;
     this._stream_output = false;
-    this._strategy =
-      strategy || new DecreaseScoreForUnconfirmedAgreement(new LeastExpensiveLinearPayuMS(), 0.5);
     this._api_config = new rest.Configuration();
     this._stack = new AsyncExitStack();
     this._task_package = task_package;
     this._conf = new _ExecutorConfig(max_workers, timeout);
     // TODO: setup precision
     this._budget_amount = parseFloat(budget);
+    this._strategy = strategy || new DecreaseScoreForUnconfirmedAgreement(
+      new LeastExpensiveLinearPayuMS(
+        60,
+        new ComLinear(1.0, { [Counter.TIME]: 1.0, [Counter.CPU]: 1.0 })
+      ),
+      0.5
+    );
     this._budget_allocations = [];
     this._rejecting_providers = new Set();
 

--- a/yajsapi/executor/index.ts
+++ b/yajsapi/executor/index.ts
@@ -431,10 +431,11 @@ export class Executor implements ComputationHistory {
           }
           if (score < SCORE_NEUTRAL) {
             try {
-              await proposal.reject();
+              const reason = "Score too low";
+              await proposal.reject(reason);
               emit(new events.ProposalRejected({
                 prop_id: proposal.id(),
-                reason: "Score too low",
+                reason: reason,
               }));
             } catch (error) {
               //suppress and log the error and continue;
@@ -452,11 +453,12 @@ export class Executor implements ComputationHistory {
                   common_platforms[0];
               } else {
                 try {
-                  await proposal.reject();
+                  const reason = "No common payment platforms";
+                  await proposal.reject(reason);
                   emit(
                     new events.ProposalRejected({
                       prop_id: proposal.id,
-                      reason: "No common payment platforms",
+                      reason: reason,
                     })
                   );
                 } catch (error) {
@@ -466,15 +468,16 @@ export class Executor implements ComputationHistory {
               let timeout = proposal.props()[DEBIT_NOTE_ACCEPTANCE_TIMEOUT_PROP];
               if (timeout) {
                 if (timeout < DEBIT_NOTE_MIN_TIMEOUT) {
+                  const reason = "Debit note acceptance timeout too short";
                   try {
-                    await proposal.reject();
+                    await proposal.reject(reason);
                   } catch (e) {
                     // with contextlib.suppress(Exception):
                   }
                   emit(
                     new events.ProposalRejected({
                       prop_id: proposal.id,
-                      reason: "Debit note acceptance timeout too short",
+                      reason: reason,
                     })
                   );
                 } else {

--- a/yajsapi/executor/strategy.ts
+++ b/yajsapi/executor/strategy.ts
@@ -104,9 +104,9 @@ export class LeastExpensiveLinearPayuMS {
       }
     }
 
-    if (this._max_fixed_price) {
+    if (this._max_fixed_price !== undefined) {
       const fixed_price_cap = this._max_fixed_price;
-      if (fixed_price_cap !== undefined && linear.fixed_price > fixed_price_cap) {
+      if (linear.fixed_price > fixed_price_cap) {
         logger.debug(`Rejected offer ${offer.id()}: fixed price higher than fixed price cap ${fixed_price_cap}.`);
         return SCORE_REJECTED;
       }

--- a/yajsapi/executor/strategy.ts
+++ b/yajsapi/executor/strategy.ts
@@ -14,11 +14,6 @@ export const SCORE_NEUTRAL: number = 0.0;
 export const SCORE_REJECTED: number = -1.0;
 export const SCORE_TRUSTED: number = 100.0;
 
-export const CFF_DEFAULT_PRICE_FOR_COUNTER: Map<Counter, number> = new Map([
-  [Counter.TIME, parseFloat("0.002")],
-  [Counter.CPU, parseFloat("0.002") * 10],
-]);
-
 export interface ComputationHistory {
   rejected_last_agreement: (string) => boolean;
 }
@@ -39,7 +34,10 @@ class MarketGeneral {}
 applyMixins(MarketGeneral, [MarketStrategy, Object]);
 
 export class DummyMS extends MarketGeneral {
-  max_for_counter: Map<Counter, Number> = CFF_DEFAULT_PRICE_FOR_COUNTER;
+  max_for_counter: Map<Counter, Number> = new Map([
+    [Counter.TIME, parseFloat("0.002")],
+    [Counter.CPU, parseFloat("0.002") * 10],
+  ]);
   max_fixed: Number = parseFloat("0.05");
   _activity?: Activity;
 

--- a/yajsapi/executor/strategy.ts
+++ b/yajsapi/executor/strategy.ts
@@ -69,10 +69,17 @@ export class DummyMS extends MarketGeneral {
 
 export class LeastExpensiveLinearPayuMS {
   private _expected_time_secs: number;
-  private _price_caps?: ComLinear;
-  constructor(expected_time_secs: number = 60, price_caps?: ComLinear) {
+  private _max_fixed_price?: number;
+  private _max_price_for?: Map<Counter, number>
+
+  constructor(
+    expected_time_secs: number = 60,
+    max_fixed_price?: number,
+    max_price_for?: Map<Counter, number>
+  ) {
     this._expected_time_secs = expected_time_secs;
-    if (price_caps) this._price_caps = price_caps;
+    if (max_fixed_price) this._max_fixed_price = max_fixed_price;
+    if (max_price_for) this._max_price_for = max_price_for;
   }
 
   async decorate_demand(demand: DemandBuilder): Promise<void> {
@@ -97,10 +104,10 @@ export class LeastExpensiveLinearPayuMS {
       }
     }
 
-    if (this._price_caps) {
-      const fixed_price_cap = this._price_caps.fixed_price;
+    if (this._max_fixed_price) {
+      const fixed_price_cap = this._max_fixed_price;
       if (fixed_price_cap !== undefined && linear.fixed_price > fixed_price_cap) {
-        logger.debug(`Rejected offer ${offer.id()}: fixed price higher than fixed price cap=${fixed_price_cap}.`);
+        logger.debug(`Rejected offer ${offer.id()}: fixed price higher than fixed price cap ${fixed_price_cap}.`);
         return SCORE_REJECTED;
       }
     }
@@ -115,10 +122,10 @@ export class LeastExpensiveLinearPayuMS {
         logger.debug(`Rejected offer ${offer.id()}: negative price for '${resource}'`);
         return SCORE_REJECTED;
       }
-      if (this._price_caps) {
-        const resource_cap = this._price_caps.price_for[resource];
-        if (resource_cap !== undefined && linear.price_for[resource] > resource_cap) {
-          logger.debug(`Rejected offer ${offer.id()}: price for '${resource}' higher than price cap=${resource_cap}`);
+      if (this._max_price_for) {
+        const max_price = this._max_price_for.get(resource as Counter)
+        if (max_price !== undefined && linear.price_for[resource] > max_price) {
+          logger.debug(`Rejected offer ${offer.id()}: price for '${resource}' higher than price cap ${max_price}`);
           return SCORE_REJECTED;
         }
       }

--- a/yajsapi/props/com.ts
+++ b/yajsapi/props/com.ts
@@ -31,12 +31,6 @@ export class ComLinear extends Com {
   public fixed_price!: number;
   public price_for!: Object;
 
-  constructor(fixed_price: number = 0, price_for: Object = {}) {
-    super();
-    this.fixed_price = fixed_price;
-    this.price_for = price_for;
-  }
-
   _custom_mapping(props, data: any) {
     if (data["price_model"] != PriceModel.LINEAR)
       throw "expected linear pricing model";

--- a/yajsapi/props/com.ts
+++ b/yajsapi/props/com.ts
@@ -31,6 +31,12 @@ export class ComLinear extends Com {
   public fixed_price!: number;
   public price_for!: Object;
 
+  constructor(fixed_price: number = 0, price_for: Object = {}) {
+    super();
+    this.fixed_price = fixed_price;
+    this.price_for = price_for;
+  }
+
   _custom_mapping(props, data: any) {
     if (data["price_model"] != PriceModel.LINEAR)
       throw "expected linear pricing model";

--- a/yajsapi/rest/market.ts
+++ b/yajsapi/rest/market.ts
@@ -149,7 +149,7 @@ export class OfferProposal {
       await this._subscription._api.rejectProposalOffer(
         this._subscription.id(),
         this.id(),
-        { message: "Rejected" as Object }
+        { message: (_reason || "no reason") as Object }
       );
     } catch (e) {
       logger.debug(`Cannot reject offer ${this.id()}` + e.response.data.message);

--- a/yajsapi/rest/market.ts
+++ b/yajsapi/rest/market.ts
@@ -145,10 +145,16 @@ export class OfferProposal {
   }
 
   async reject(_reason: string | null = null) {
-    await this._subscription._api.rejectProposalOffer(
-      this._subscription.id(),
-      this.id()
-    );
+    try {
+      await this._subscription._api.rejectProposalOffer(
+        this._subscription.id(),
+        this.id(),
+        { message: "Rejected" as Object }
+      );
+    } catch (e) {
+      logger.debug(`Cannot reject offer ${this.id()}` + e.response.data.message);
+      throw(e);
+    }
   }
 
   async respond(props: object, constraints: string): Promise<string> {


### PR DESCRIPTION
• Add computation price caps
• Fix HTTP 400 on `.reject()`
• Update default Executor timeout to 15 min (yapapi PR #255)
• Bug fix (`stdout` -> `stderr`)