### PR TITLE
Return batch results with optional blocking

### DIFF
--- a/yajsapi/executor/ctx.ts
+++ b/yajsapi/executor/ctx.ts
@@ -273,6 +273,11 @@ class _Steps extends Work {
   }
 }
 
+export class ExecOptions {
+  wait_for_results: boolean = true;
+  batch_timeout?: number;
+}
+
 /**
  * An object used to schedule commands to be sent to provider.
  */

--- a/yajsapi/executor/ctx.ts
+++ b/yajsapi/executor/ctx.ts
@@ -275,7 +275,7 @@ class _Steps extends Work {
 
 export class ExecOptions {
   wait_for_results: boolean = true;
-  batch_timeout?: number;
+  batch_timeout?: number | null;
 }
 
 /**

--- a/yajsapi/executor/index.ts
+++ b/yajsapi/executor/index.ts
@@ -701,7 +701,7 @@ export class Executor {
             try {
               let tasks = task_emitter(consumer);
               const batch_generator = worker(work_context, tasks);
-              process_batches(agreement.id(), act, batch_generator, consumer);
+              await process_batches(agreement.id(), act, batch_generator, consumer);
               emit(new events.WorkerFinished({ agr_id: agreement.id(), exception: undefined }));
             } catch (error) {
               emit(new events.WorkerFinished({ agr_id: agreement.id(), exception: error }));

--- a/yajsapi/executor/index.ts
+++ b/yajsapi/executor/index.ts
@@ -615,6 +615,11 @@ export class Executor {
           }));
         }
         const task_id = current_worker_task ? current_worker_task.id : undefined;
+        batch.attestation = {
+          credentials: activity.credentials,
+          nonce: activity.id,
+          exeunitHashes: activity.exeunitHashes,
+        };
         await batch.prepare();
         const cc = new CommandContainer();
         batch.register(cc);

--- a/yajsapi/executor/index.ts
+++ b/yajsapi/executor/index.ts
@@ -255,7 +255,7 @@ export class Executor {
   async *submit(
     worker: Callable<
       [WorkContext, AsyncIterable<Task<D, R>>],
-      AsyncGenerator<WorkItem, any> /* TODO any -> Awaitable[List[events.CommandEvent]] */
+      AsyncGenerator<WorkItem, any, BatchResults>
     >,
     data: Iterable<Task<D, R>>
   ): AsyncGenerator<Task<D, R>> {
@@ -379,7 +379,7 @@ export class Executor {
   async *_submit(
     worker: Callable<
       [WorkContext, AsyncIterable<Task<D, R>>],
-      AsyncGenerator<WorkItem, any> /* TODO any -> Awaitable[List[events.CommandEvent]] */
+      AsyncGenerator<WorkItem, any, BatchResults>
     >,
     data: Iterable<Task<D, R>>
   ): AsyncGenerator<Task<D, R>> {

--- a/yajsapi/executor/index.ts
+++ b/yajsapi/executor/index.ts
@@ -560,7 +560,7 @@ export class Executor {
           }
         }
         const batch_deadline
-          = exec_options.batch_timeout ? (Date.now() + exec_options.batch_timeout) : undefined;
+          = exec_options.batch_timeout ? ((Date.now() + exec_options.batch_timeout) / 1000) : undefined;
         const current_worker_task = consumer.last_item();
         if (current_worker_task) {
           emit(new events.TaskStarted({
@@ -623,8 +623,8 @@ export class Executor {
             try {
               return await get_batch_results();
             } catch (error) {
-              logger.error(`Error while getting batch results: ${error}`);
-              return []; // TODO
+              logger.warn(`Error while getting batch results: ${error}`);
+              throw error;
             }
           })();
           ({ done = false, value: item } = await command_generator.next(get_results));

--- a/yajsapi/executor/index.ts
+++ b/yajsapi/executor/index.ts
@@ -645,14 +645,14 @@ export class Executor {
         if (exec_options.wait_for_results) {
           // Block until the results are available
           try {
-            let results = await get_batch_results(); // TODO
-            item = (await command_generator.next(results)).value;
+            let results = await get_batch_results();
+            item = (await command_generator.next(async () => results)).value;
           } catch (e) {
             // TODO
           }
         } else {
           // Schedule the coroutine in a separate task
-          item = (await command_generator.next(get_batch_results()));
+          item = (await command_generator.next(get_batch_results())).value;
         }
       }
     }

--- a/yajsapi/executor/index.ts
+++ b/yajsapi/executor/index.ts
@@ -237,7 +237,7 @@ export class Executor {
   async *submit(
     worker: Callable<
       [WorkContext, AsyncIterable<Task<D, R>>],
-      AsyncGenerator<Work, any> /* TODO any -> Awaitable[List[events.CommandEvent]] */
+      AsyncGenerator<WorkItem, any> /* TODO any -> Awaitable[List[events.CommandEvent]] */
     >,
     data: Iterable<Task<D, R>>
   ): AsyncGenerator<Task<D, R>> {
@@ -255,7 +255,7 @@ export class Executor {
   async *_submit(
     worker: Callable<
       [WorkContext, AsyncIterable<Task<D, R>>],
-      AsyncGenerator<Work, any> /* TODO any -> Awaitable[List[events.CommandEvent]] */
+      AsyncGenerator<WorkItem, any> /* TODO any -> Awaitable[List[events.CommandEvent]] */
     >,
     data: Iterable<Task<D, R>>
   ): AsyncGenerator<Task<D, R>> {
@@ -587,7 +587,7 @@ export class Executor {
     async function process_batches(
       agreement_id: string,
       activity: rest.Activity,
-      command_generator: AsyncGenerator<Work, any>,
+      command_generator: AsyncGenerator<WorkItem, any>,
       consumer: Consumer<Task<D, R>>
     ): Promise<void> {
       /* TODO ctrl+c handling */

--- a/yajsapi/executor/index.ts
+++ b/yajsapi/executor/index.ts
@@ -618,7 +618,7 @@ export class Executor {
             ({ done = false, value: item } = await command_generator.next((async () => results)()));
           }
         } else {
-          // Run without blocking, user may await the next
+          // Run without blocking
           const get_results = (async () => {
             try {
               return await get_batch_results();

--- a/yajsapi/executor/index.ts
+++ b/yajsapi/executor/index.ts
@@ -553,7 +553,7 @@ export class Executor {
         if (batch.timeout()) {
           if (exec_options.batch_timeout) {
             logger.warn(
-              "Overriding batch timeout set with commit(batch_timeout) by the value set in exec options"
+              "Overriding batch timeout set with commit({timeout:...}) by value from ExecOptions"
             );
           } else {
             exec_options.batch_timeout = batch.timeout();
@@ -621,10 +621,11 @@ export class Executor {
           // Run without blocking
           const get_results = (async () => {
             try {
-              return await get_batch_results();
+              let results = await get_batch_results();
+              return new Promise((resolve, reject) => resolve(results) );
             } catch (error) {
               logger.warn(`Error while getting batch results: ${error}`);
-              throw error;
+              return new Promise((resolve, reject) => reject(error) );
             }
           })();
           ({ done = false, value: item } = await command_generator.next(get_results));

--- a/yajsapi/executor/index.ts
+++ b/yajsapi/executor/index.ts
@@ -591,7 +591,7 @@ export class Executor {
       consumer: Consumer<Task<D, R>>
     ): Promise<void> {
       /* TODO ctrl+c handling */
-      const item = await (await command_generator.next()).value;
+      let item = (await command_generator.next()).value;
       while (true) {
         const [batch, exec_options] = unpack_work_item(item);
         if (batch.timeout()) {
@@ -644,10 +644,15 @@ export class Executor {
         }
         if (exec_options.wait_for_results) {
           // Block until the results are available
-          /* TODO */
+          try {
+            let results = await get_batch_results(); // TODO
+            item = (await command_generator.next(results)).value;
+          } catch (e) {
+            // TODO
+          }
         } else {
-          // Schedule the coroutine in a separate asyncio task
-          /* TODO */
+          // Schedule the coroutine in a separate task
+          item = (await command_generator.next(get_batch_results()));
         }
       }
     }

--- a/yajsapi/executor/index.ts
+++ b/yajsapi/executor/index.ts
@@ -650,14 +650,17 @@ export class Executor {
         }
         if (exec_options.wait_for_results) {
           // Block until the results are available
+          let results;
           try {
-            let results = await get_batch_results();
-            ({ done = false, value: item } = await command_generator.next(async () => results));
+            results = await get_batch_results();
           } catch (error) {
             // Raise the exception in `command_generator` (the `worker` coroutine).
             // If the client code is able to handle it then we'll proceed with
             // subsequent batches. Otherwise the worker finishes with error.
             ({ done = false, value: item } = await command_generator.throw(error));
+          }
+          if (results !== undefined) {
+            ({ done = false, value: item } = await command_generator.next(async () => results));
           }
         } else {
           // Schedule the coroutine in a separate task

--- a/yajsapi/index.ts
+++ b/yajsapi/index.ts
@@ -1,4 +1,4 @@
-import { Executor, Task, sgx, vm } from "./executor";
+import { BatchResults, Executor, Task, sgx, vm } from "./executor";
 import { WorkContext, Work, ExecOptions } from "./executor/ctx";
 import * as props from "./props";
 import * as rest from "./rest";
@@ -12,4 +12,4 @@ import * as utils from "./utils";
 //   console.log('Unhandled Rejection at: Promise', p, 'reason:', reason);
 // });
 
-export { Executor, ExecOptions, Task, sgx, vm, Work, WorkContext, props, rest, storage, utils };
+export { Executor, ExecOptions, Task, sgx, vm, Work, WorkContext, BatchResults, props, rest, storage, utils };

--- a/yajsapi/index.ts
+++ b/yajsapi/index.ts
@@ -1,5 +1,5 @@
 import { Executor, Task, sgx, vm } from "./executor";
-import { WorkContext } from "./executor/ctx";
+import { WorkContext, Work, ExecOptions } from "./executor/ctx";
 import * as props from "./props";
 import * as rest from "./rest";
 import * as storage from "./storage";
@@ -12,4 +12,4 @@ import * as utils from "./utils";
 //   console.log('Unhandled Rejection at: Promise', p, 'reason:', reason);
 // });
 
-export { Executor, Task, sgx, vm, WorkContext, props, rest, storage, utils };
+export { Executor, ExecOptions, Task, sgx, vm, Work, WorkContext, props, rest, storage, utils };

--- a/yajsapi/rest/activity.ts
+++ b/yajsapi/rest/activity.ts
@@ -154,7 +154,7 @@ class ExeScriptRequest implements yaa.ExeScriptRequest {
 }
 
 // Mid-level wrapper for REST's Activity endpoint
-class Activity {
+export class Activity {
   protected _api!: RequestorControlApi;
   protected _state!: RequestorStateApi;
   protected _id!: string;

--- a/yajsapi/rest/index.ts
+++ b/yajsapi/rest/index.ts
@@ -1,12 +1,13 @@
 import { Configuration } from "./configuration";
 import { Market } from "./market";
 import { Invoice, InvoiceStatus, Payment } from "./payment";
-import { ActivityService as Activity } from "./activity";
+import { ActivityService, Activity } from "./activity";
 import * as sgx from "../package/sgx";
 import * as vm from "../package/vm";
 
 export {
   Activity,
+  ActivityService,
   Configuration,
   Invoice,
   InvoiceStatus,


### PR DESCRIPTION
- [x] check timeout units (s/ms)
- [x] ctrl+c in `process_batches`
- [x] test `yield`ing pairs from the worker function
- [x] test `wait_for_results: false`.
- [x] smart queue fixes (`yapapi`: #394)
- [x] pass command errors to worker functions (also #394)