### PR TITLE
Update goth to version 0.10+

### DIFF
--- a/.github/workflows/goth-nightly.yml
+++ b/.github/workflows/goth-nightly.yml
@@ -22,7 +22,7 @@ jobs:
         id: latest-stable
         # second sed expression removes leading whitespaces and '*' characters (git uses it to indicate the current branch)
         run: |
-          branch=$(git branch -a | sed -e 's:remotes/origin/::' -e 's:^[ \t*]*::' | grep -E '^release\/v[0-9]+(\.[0-9]+)+$' | sort -Vr | head -1)
+          branch=$(git branch -a | sed -e 's:remotes/origin/::' -e 's:^[ \t*]*::' | grep -E '^b[0-9]+(\.[0-9]+)+$' | sort -Vr | head -1)
           echo "::set-output name=branch::$branch"
 
       # prepares JSON object representing strategy matrix which contains two 'branch' variants: master and latest stable
@@ -136,5 +136,5 @@ jobs:
           REPO_NAME: ${{ github.repository }}
           WORKFLOW_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
         with:
-          # <@&717623005911580713> = @sdk-integrations
+          # <@&717623005911580713> = @sdk
           args: '<@&717623005911580713> Goth nightly run failed for `{{ REPO_NAME }}` on branch `{{ BRANCH_NAME }}`! <{{ WORKFLOW_URL }}>'

--- a/tests/goth/pyproject.toml
+++ b/tests/goth/pyproject.toml
@@ -22,7 +22,7 @@ readme = "README.md"
 python = "^3.8.0"
 pytest = "^6.2"
 pytest-asyncio = "^0.14"
-goth = "^0.9"
+goth = "^0.10"
 
 [tool.poetry.dev-dependencies]
 black = "^20.8b1"

--- a/tests/goth/pyproject.toml
+++ b/tests/goth/pyproject.toml
@@ -22,6 +22,7 @@ readme = "README.md"
 python = "^3.8.0"
 pytest = "^6.2"
 pytest-asyncio = "^0.14"
+pytest-rerunfailures = "^10.1"
 goth = "^0.10"
 
 [tool.poetry.dev-dependencies]
@@ -32,5 +33,5 @@ poethepoet = "^0.8.0"
 [tool.poe.tasks]
 codestyle = "black --check --diff ."
 goth-assets = "python -m goth create-assets assets"
-goth-tests = "pytest -svx ."
+goth-tests = "pytest -svx . --reruns 3 --only-rerun AssertionError --only-rerun TimeoutError --only-rerun goth.runner.exceptions.TemporalAssertionError --only-rerun urllib.error.URLError --only-rerun goth.runner.exceptions.CommandError"
 typecheck = "mypy ."

--- a/tests/goth/test_agreement_termination/test_agreement_termination.py
+++ b/tests/goth/test_agreement_termination/test_agreement_termination.py
@@ -85,6 +85,7 @@ async def test_agreement_termination(
         async with requestor.run_command_on_host(f"node {test_script_path}", env=os.environ) as (
             _cmd_task,
             cmd_monitor,
+            _process_monitor,
         ):
 
             cmd_monitor.add_assertion(assert_all_tasks_computed)

--- a/tests/goth/test_multiactivity_agreement/test_multiactivity_agreement.py
+++ b/tests/goth/test_multiactivity_agreement/test_multiactivity_agreement.py
@@ -71,7 +71,7 @@ async def test_multiactivity_agreement(project_dir: Path, log_dir: Path, config_
 
         async with requestor.run_command_on_host(
             f"node {requestor_path}", env=os.environ
-        ) as (_cmd_task, cmd_monitor):
+        ) as (_cmd_task, cmd_monitor, _process_monitor):
 
             # Wait for agreement
             assertion = cmd_monitor.add_assertion(assert_agreement_created)

--- a/tests/goth/test_run_blender.py
+++ b/tests/goth/test_run_blender.py
@@ -105,18 +105,13 @@ async def test_run_blender(
         async with requestor.run_command_on_host(
             f"node {blender_path} --subnet-tag goth",
             env=os.environ,
-        ) as (_cmd_task, cmd_monitor):
+        ) as (_cmd_task, cmd_monitor, _process_monitor):
 
             # Add assertions to the command output monitor `cmd_monitor`:
             cmd_monitor.add_assertion(assert_no_errors)
             cmd_monitor.add_assertion(assert_all_invoices_accepted)
             all_sent = cmd_monitor.add_assertion(assert_all_tasks_sent)
             all_computed = cmd_monitor.add_assertion(assert_all_tasks_computed)
-
-            await cmd_monitor.wait_for_pattern(
-                ".*Received proposals from 2 ", timeout=20
-            )
-            logger.info("Received proposals")
 
             await cmd_monitor.wait_for_pattern(".*Agreement proposed ", timeout=20)
             logger.info("Agreement proposed")

--- a/tests/goth/test_run_yacat.py
+++ b/tests/goth/test_run_yacat.py
@@ -105,7 +105,7 @@ async def test_run_yacat(
             r"--mask ?a?a --hash \$P\$5ZDzPE45CigTC6EY4cXbyJSLj/pGee0 "
             "--subnet-tag goth --number-of-providers 2",
             env=os.environ,
-        ) as (_cmd_task, cmd_monitor):
+        ) as (_cmd_task, cmd_monitor, _process_monitor):
 
             # Add assertions to the command output monitor `cmd_monitor`:
             cmd_monitor.add_assertion(assert_no_errors)


### PR DESCRIPTION
This is to prevent an issue with one of `goth`'s transitive dependencies, a similar issue is decribed here: https://github.com/aws/aws-sam-cli/issues/3661

This PR also includes some Actions workflow improvements:
- integration test reruns for some specific exceptions using `pytest-rerunfailures`
- fix Actions job responsible for getting the latest stable branch name