### PR TITLE
Change default payment network rinkeby->goerli

### DIFF
--- a/examples/blender/blender.ts
+++ b/examples/blender/blender.ts
@@ -1,7 +1,7 @@
 import { TaskExecutor } from "yajsapi";
 import { program } from "commander";
 import { fileURLToPath } from "url";
-const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
 
 const blender_params = (frame) => ({
   scene_file: "/golem/resource/scene.blend",
@@ -40,13 +40,10 @@ async function main(subnetTag: string, driver?: string, network?: string, debug?
       .beginBatch()
       .uploadJson(blender_params(frame), "/golem/work/params.json")
       .run("/golem/entrypoints/run-blender.sh")
-      .downloadFile(
-        `/golem/output/out${frame?.toString().padStart(4, "0")}.png`,
-        `${__dirname}/output_${frame}.png`
-      )
+      .downloadFile(`/golem/output/out${frame?.toString().padStart(4, "0")}.png`, `${__dirname}/output_${frame}.png`)
       .end()
-      .catch(e => console.error(e))
-    return result?.length ? `output_${frame}.png` : '';
+      .catch((e) => console.error(e));
+    return result?.length ? `output_${frame}.png` : "";
   });
   for await (const result of results) console.log(result);
   await executor.end();
@@ -55,7 +52,7 @@ async function main(subnetTag: string, driver?: string, network?: string, debug?
 program
   .option("--subnet-tag <subnet>", "set subnet name, for example 'public'")
   .option("--payment-driver, --driver <driver>", "payment driver name, for example 'erc20'")
-  .option("--payment-network, --network <network>", "network name, for example 'rinkeby'")
+  .option("--payment-network, --network <network>", "network name, for example 'goerli'")
   .option("-d, --debug", "output extra debugging")
   .option("-t, --max-parallel-tasks <maxParallelTasks>", "max parallel tasks");
 program.parse();

--- a/examples/fibonacci/fibonacci.js
+++ b/examples/fibonacci/fibonacci.js
@@ -1,19 +1,18 @@
 import { TaskExecutor } from "yajsapi";
 import { program } from "commander";
 
-async function main(fibo_n = 1, tasks_count = 1, subnet_tag, payment_driver, payment_network, debug) {
+async function main(fiboN = 1, tasksCount = 1, subnetTag, driver, network, debug) {
   const executor = await TaskExecutor.create({
     package: "529f7fdaf1cf46ce3126eb6bbcd3b213c314fe8fe884914f5d1106d4",
-    subnet_tag,
-    payment_driver,
-    payment_network,
+    subnetTag,
+    payment: { driver, network },
     logLevel: debug ? "debug" : "info",
   });
 
-  const data = Array(tasks_count).fill(null);
+  const data = Array(tasksCount).fill(null);
 
   await executor.forEach(data, async (ctx) => {
-    const result = await ctx.run("/usr/local/bin/node", ["/golem/work/fibo.js", fibo_n.toString()]);
+    const result = await ctx.run("/usr/local/bin/node", ["/golem/work/fibo.js", fiboN.toString()]);
     console.log(result.stdout);
   });
   await executor.end();
@@ -23,7 +22,7 @@ program
   .option("-c, --tasks-count <c>", "tasks count", (val) => parseInt(val))
   .option("--subnet-tag <subnet>", "set subnet name, for example 'public'")
   .option("--payment-driver, --driver <driver>", "payment driver name, for example 'erc20'")
-  .option("--payment-network, --network <network>", "network name, for example 'rinkeby'")
+  .option("--payment-network, --network <network>", "network name, for example 'goerli'")
   .option("-d, --debug", "output extra debugging");
 program.parse();
 const options = program.opts();

--- a/examples/mid-level-api/hello.ts
+++ b/examples/mid-level-api/hello.ts
@@ -23,7 +23,7 @@ async function main() {
   const logger = new ConsoleLogger();
   const taskPackage = await Package.create({ imageHash: "9a3b5d67b0b27746283cb5f287c13eab1beaa12d92a9f536b747c7ae" });
   const accounts = await (await Accounts.create()).list();
-  const account = accounts.find((account) => account?.platform.indexOf("erc20") !== -1);
+  const account = accounts.find((account) => account?.platform.indexOf("erc20-goerli") !== -1);
   if (!account) throw new Error("There is no available account");
   const allocation = await Allocation.create({ account, logger });
   const demand = await Demand.create(taskPackage, [allocation], { logger });

--- a/examples/ssh/ssh.ts
+++ b/examples/ssh/ssh.ts
@@ -42,11 +42,11 @@ async function main(subnetTag, driver, network, count = 2, sessionTimeout = 100,
 
 program
   .option("--subnet-tag <subnet>", "set subnet name, for example 'public'")
-  .option("--payment-driver <payment_driver>", "payment driver name, for example 'erc20'")
-  .option("--payment-network <payment_network>", "network name, for example 'rinkeby'")
+  .option("--payment-driver <paymentDriver>", "payment driver name, for example 'erc20'")
+  .option("--payment-network <paymentNetwork>", "network name, for example 'goerli'")
   .option("--task-count, --count <count>", "task count", (val) => parseInt(val))
   .option("-t, --timeout <timeout>", "ssh session timeout (in seconds)", (val) => parseInt(val))
   .option("-d, --debug", "output extra debugging");
 program.parse();
 const options = program.opts();
-main(options.subnetTag, options.payment_driver, options.payment_network, options.count, options.timeout, options.debug);
+main(options.subnetTag, options.paymentDriver, options.paymentNetwork, options.count, options.timeout, options.debug);

--- a/examples/web/executor/hello.html
+++ b/examples/web/executor/hello.html
@@ -32,6 +32,10 @@
                             <label for="SUBNET_TAG">Subnet Tag: </label>
                             <input id="SUBNET_TAG" type="text" value="public" />
                         </div>
+                        <div>
+                            <label for="PAYMENT_NETWORK">Payment Network: </label>
+                            <input id="PAYMENT_NETWORK" type="text" value="goerli" />
+                        </div>
                     </div>
                 </div>
             </div>

--- a/examples/web/executor/hello.html
+++ b/examples/web/executor/hello.html
@@ -87,10 +87,12 @@
           const basePath = document.getElementById('YAGNA_API_BASEPATH').value;
           const subnetTag = document.getElementById('SUBNET_TAG').value;
           const imageHash = document.getElementById('IMAGE_HASH').value;
+          const network = document.getElementById('PAYMENT_NETWORK').value;
             const executor = await TaskExecutor.create({
                 yagnaOptions: { apiKey, basePath },
                 package: imageHash,
                 subnetTag,
+                payment: { network },
                 logger
               })
             await executor

--- a/examples/web/executor/image.html
+++ b/examples/web/executor/image.html
@@ -117,11 +117,13 @@
         async function run() {
             const apiKey = document.getElementById('YAGNA_APPKEY').value;
             const basePath = document.getElementById('YAGNA_API_BASEPATH').value;
+            const network = document.getElementById('PAYMENT_NETWORK').value;
             const chunkedImg = chunkString(encodedImg.value, 64000)
 
             const executor = await TaskExecutor.create({
                 yagnaOptions: { apiKey, basePath },
                 package:"6539a63fecfb4ce98bc838ab2de71c6f4d36e1ee5945fbd8f1165c48",
+                payment: { network },
                 logger
               })
 

--- a/examples/web/executor/image.html
+++ b/examples/web/executor/image.html
@@ -20,6 +20,10 @@
                     <input id="YAGNA_API_BASEPATH" type="text" value="http://127.0.0.1:7465" />
                 </div>
                 <div>
+                    <label for="PAYMENT_NETWORK">Payment Network: </label>
+                    <input id="PAYMENT_NETWORK" type="text" value="goerli" />
+                </div>
+                <div>
                     <label for="MEME_TEXT">Meme Text: </label>
                     <input id="MEME_TEXT" type="text" value="some meme text" />
                 </div>

--- a/examples/web/mid_level/index.html
+++ b/examples/web/mid_level/index.html
@@ -176,7 +176,7 @@
         async function createAllocation() {
           options = getOptions();
           const accounts = await (await yajsapi.Accounts.create(options)).list();
-          options.account = accounts.find(account => account?.platform.indexOf('erc20') !== -1);
+          options.account = accounts.find(account => account?.platform.indexOf('erc20-rinkeby') !== -1);
           allocation = await yajsapi.Allocation.create(options).catch(logger.error);
           enableButtons();
         }

--- a/examples/web/mid_level/index.html
+++ b/examples/web/mid_level/index.html
@@ -50,6 +50,12 @@
                             <input id="BUDGET" type="number" value="1" />
                         </div>
                     </div>
+                    <div class="row">
+                        <div>
+                            <label for="PAYMENT_NETWORK">Payment Network: </label>
+                            <input id="PAYMENT_NETWORK" type="text" value="goerli" />
+                        </div>
+                    </div>
                 </div>
             </div>
 

--- a/examples/web/mid_level/index.html
+++ b/examples/web/mid_level/index.html
@@ -158,9 +158,11 @@
           const minStorageGib = document.getElementById('MIN_STORAGE_GIB').value;
           const minCpuThreads = document.getElementById('MIN_CPU').value;
           const subnetTag = document.getElementById('SUBNET_TAG').value;
+          const network = document.getElementById('PAYMENT_NETWORK').value;
           return  {
             yagnaOptions: { apiKey, basePath },
             imageHash, minCpuThreads,minStorageGib, minMemGib,
+            payment: { network },
             logger,
             subnetTag
           }

--- a/examples/yacat/yacat.ts
+++ b/examples/yacat/yacat.ts
@@ -52,7 +52,7 @@ async function main(args) {
 program
   .option("--subnet-tag <subnet>", "set subnet name, for example 'public'")
   .option("--payment-driver, --driver <driver>", "payment driver name, for example 'erc20'")
-  .option("--payment-network, --network <network>", "network name, for example 'rinkeby'")
+  .option("--payment-network, --network <network>", "network name, for example 'goerli'")
   .option("-d, --debug", "output extra debugging")
   .option("--number-of-providers <number_of_providers>", "number of providers", (value) => parseInt(value), 2)
   .option("--mask <mask>")

--- a/tests/cypress/ui/hello_world.cy.ts
+++ b/tests/cypress/ui/hello_world.cy.ts
@@ -4,6 +4,7 @@ describe("Test TaskExecutor API", () => {
     cy.get("#YAGNA_APPKEY").clear().type(Cypress.env("YAGNA_APPKEY"));
     cy.get("#YAGNA_API_BASEPATH").clear().type(Cypress.env("YAGNA_API_BASEPATH"));
     cy.get("#SUBNET_TAG").clear().type(Cypress.env("YAGNA_SUBNET"));
+    cy.get("#PAYMENT_NETWORK").clear().type("rinkeby");
     cy.get("#echo").click();
     cy.get("#results").should("include.text", "Hello World", { timeout: 60000 });
     cy.get("#logs").contains("Task Executor has shut down");

--- a/tests/cypress/ui/mid_level.cy.ts
+++ b/tests/cypress/ui/mid_level.cy.ts
@@ -4,6 +4,7 @@ describe("Test Mid-level API", () => {
     cy.get("#YAGNA_APPKEY").clear().type(Cypress.env("YAGNA_APPKEY"));
     cy.get("#YAGNA_API_BASEPATH").clear().type(Cypress.env("YAGNA_API_BASEPATH"));
     cy.get("#SUBNET_TAG").clear().type(Cypress.env("YAGNA_SUBNET"));
+    cy.get("#PAYMENT_NETWORK").clear().type("rinkeby");
     cy.get("#createPackage").click().debug();
     cy.get("#logs").contains("Package created");
     cy.get("#createAllocation").click();

--- a/tests/integration/blender.spec.ts
+++ b/tests/integration/blender.spec.ts
@@ -33,7 +33,7 @@ describe("Blender rendering", function () {
     executor = await TaskExecutor.create({
       package: "9a3b5d67b0b27746283cb5f287c13eab1beaa12d92a9f536b747c7ae",
       logger,
-      payment: { network: "rinkeby " },
+      payment: { network: "rinkeby" },
     });
     executor.beforeEach(async (ctx) => {
       await ctx.uploadFile(

--- a/tests/integration/blender.spec.ts
+++ b/tests/integration/blender.spec.ts
@@ -33,6 +33,7 @@ describe("Blender rendering", function () {
     executor = await TaskExecutor.create({
       package: "9a3b5d67b0b27746283cb5f287c13eab1beaa12d92a9f536b747c7ae",
       logger,
+      payment: { network: "rinkeby " },
     });
     executor.beforeEach(async (ctx) => {
       await ctx.uploadFile(

--- a/tests/integration/mid_level.spec.ts
+++ b/tests/integration/mid_level.spec.ts
@@ -27,7 +27,7 @@ describe("Mid-level modules", () => {
     const accounts = await (await Accounts.create()).list();
     const account = accounts[0];
     const taskPackage = await Package.create({ imageHash: "9a3b5d67b0b27746283cb5f287c13eab1beaa12d92a9f536b747c7ae" });
-    const allocation = await Allocation.create({ account, logger, payment: { network: "rinkeby " } });
+    const allocation = await Allocation.create({ account, logger, payment: { network: "rinkeby" } });
     const demand = await Demand.create(taskPackage, [allocation], { logger });
     const offer: Proposal = await new Promise((res) =>
       demand.addEventListener(DemandEventType, async (event) => {

--- a/tests/integration/mid_level.spec.ts
+++ b/tests/integration/mid_level.spec.ts
@@ -25,7 +25,8 @@ describe("Mid-level modules", () => {
 
   it("should run simple script on provider", async () => {
     const accounts = await (await Accounts.create()).list();
-    const account = accounts[0];
+    const account = accounts.find((account) => account?.platform.indexOf("erc20-rinkeby") !== -1);
+    if (!account) throw new Error("There is no requestor account supporting rinkeby platform");
     const taskPackage = await Package.create({ imageHash: "9a3b5d67b0b27746283cb5f287c13eab1beaa12d92a9f536b747c7ae" });
     const allocation = await Allocation.create({ account, logger, payment: { network: "rinkeby" } });
     const demand = await Demand.create(taskPackage, [allocation], { logger });

--- a/tests/integration/mid_level.spec.ts
+++ b/tests/integration/mid_level.spec.ts
@@ -27,7 +27,7 @@ describe("Mid-level modules", () => {
     const accounts = await (await Accounts.create()).list();
     const account = accounts[0];
     const taskPackage = await Package.create({ imageHash: "9a3b5d67b0b27746283cb5f287c13eab1beaa12d92a9f536b747c7ae" });
-    const allocation = await Allocation.create({ account, logger });
+    const allocation = await Allocation.create({ account, logger, payment: { network: "rinkeby " } });
     const demand = await Demand.create(taskPackage, [allocation], { logger });
     const offer: Proposal = await new Promise((res) =>
       demand.addEventListener(DemandEventType, async (event) => {

--- a/tests/integration/ssh.spec.ts
+++ b/tests/integration/ssh.spec.ts
@@ -17,7 +17,7 @@ describe("SSH connection", function () {
       capabilities: ["vpn"],
       networkIp: "192.168.0.0/24",
       logger,
-      payment: { network: "rinkeby " },
+      payment: { network: "rinkeby" },
     });
     let websocketUri;
     const password = crypto.randomBytes(3).toString("hex");

--- a/tests/integration/ssh.spec.ts
+++ b/tests/integration/ssh.spec.ts
@@ -17,6 +17,7 @@ describe("SSH connection", function () {
       capabilities: ["vpn"],
       networkIp: "192.168.0.0/24",
       logger,
+      payment: { network: "rinkeby " },
     });
     let websocketUri;
     const password = crypto.randomBytes(3).toString("hex");

--- a/tests/integration/tasks.spec.ts
+++ b/tests/integration/tasks.spec.ts
@@ -19,7 +19,7 @@ describe("Task Executor", function () {
   it("should run simple task", async () => {
     executor = await TaskExecutor.create({
       package: "9a3b5d67b0b27746283cb5f287c13eab1beaa12d92a9f536b747c7ae",
-      payment: { network: "rinkeby " },
+      payment: { network: "rinkeby" },
       logger,
     });
     const result = await executor.run(async (ctx) => ctx.run("echo 'Hello World'"));
@@ -52,7 +52,7 @@ describe("Task Executor", function () {
   it("should run simple tasks by forEach function", async () => {
     executor = await TaskExecutor.create({
       package: "9a3b5d67b0b27746283cb5f287c13eab1beaa12d92a9f536b747c7ae",
-      payment: { network: "rinkeby " },
+      payment: { network: "rinkeby" },
       logger,
     });
     const data = ["one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten"];
@@ -65,7 +65,7 @@ describe("Task Executor", function () {
   it("should run simple batch script and get results as stream", async () => {
     executor = await TaskExecutor.create({
       package: "9a3b5d67b0b27746283cb5f287c13eab1beaa12d92a9f536b747c7ae",
-      payment: { network: "rinkeby " },
+      payment: { network: "rinkeby" },
       logger,
     });
     const outputs: string[] = [];
@@ -95,7 +95,7 @@ describe("Task Executor", function () {
   it("should run simple batch script and catch error on stream", async () => {
     executor = await TaskExecutor.create({
       package: "9a3b5d67b0b27746283cb5f287c13eab1beaa12d92a9f536b747c7ae",
-      payment: { network: "rinkeby " },
+      payment: { network: "rinkeby" },
       logger,
     });
     const outputs: string[] = [];
@@ -121,7 +121,7 @@ describe("Task Executor", function () {
   it("should run simple batch script and get results as promise", async () => {
     executor = await TaskExecutor.create({
       package: "9a3b5d67b0b27746283cb5f287c13eab1beaa12d92a9f536b747c7ae",
-      payment: { network: "rinkeby " },
+      payment: { network: "rinkeby" },
       logger,
     });
     const outputs: string[] = [];
@@ -147,7 +147,7 @@ describe("Task Executor", function () {
   it("should run simple batch script and catch error on promise", async () => {
     executor = await TaskExecutor.create({
       package: "9a3b5d67b0b27746283cb5f287c13eab1beaa12d92a9f536b747c7ae",
-      payment: { network: "rinkeby " },
+      payment: { network: "rinkeby" },
       logger,
     });
     let results;
@@ -170,7 +170,7 @@ describe("Task Executor", function () {
   it("should run transfer file", async () => {
     executor = await TaskExecutor.create({
       package: "9a3b5d67b0b27746283cb5f287c13eab1beaa12d92a9f536b747c7ae",
-      payment: { network: "rinkeby " },
+      payment: { network: "rinkeby" },
       logger,
     });
     const result = await executor.run(async (ctx) => {

--- a/tests/integration/tasks.spec.ts
+++ b/tests/integration/tasks.spec.ts
@@ -19,6 +19,7 @@ describe("Task Executor", function () {
   it("should run simple task", async () => {
     executor = await TaskExecutor.create({
       package: "9a3b5d67b0b27746283cb5f287c13eab1beaa12d92a9f536b747c7ae",
+      payment: { network: "rinkeby " },
       logger,
     });
     const result = await executor.run(async (ctx) => ctx.run("echo 'Hello World'"));
@@ -51,6 +52,7 @@ describe("Task Executor", function () {
   it("should run simple tasks by forEach function", async () => {
     executor = await TaskExecutor.create({
       package: "9a3b5d67b0b27746283cb5f287c13eab1beaa12d92a9f536b747c7ae",
+      payment: { network: "rinkeby " },
       logger,
     });
     const data = ["one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten"];
@@ -63,6 +65,7 @@ describe("Task Executor", function () {
   it("should run simple batch script and get results as stream", async () => {
     executor = await TaskExecutor.create({
       package: "9a3b5d67b0b27746283cb5f287c13eab1beaa12d92a9f536b747c7ae",
+      payment: { network: "rinkeby " },
       logger,
     });
     const outputs: string[] = [];
@@ -92,6 +95,7 @@ describe("Task Executor", function () {
   it("should run simple batch script and catch error on stream", async () => {
     executor = await TaskExecutor.create({
       package: "9a3b5d67b0b27746283cb5f287c13eab1beaa12d92a9f536b747c7ae",
+      payment: { network: "rinkeby " },
       logger,
     });
     const outputs: string[] = [];
@@ -117,6 +121,7 @@ describe("Task Executor", function () {
   it("should run simple batch script and get results as promise", async () => {
     executor = await TaskExecutor.create({
       package: "9a3b5d67b0b27746283cb5f287c13eab1beaa12d92a9f536b747c7ae",
+      payment: { network: "rinkeby " },
       logger,
     });
     const outputs: string[] = [];
@@ -142,6 +147,7 @@ describe("Task Executor", function () {
   it("should run simple batch script and catch error on promise", async () => {
     executor = await TaskExecutor.create({
       package: "9a3b5d67b0b27746283cb5f287c13eab1beaa12d92a9f536b747c7ae",
+      payment: { network: "rinkeby " },
       logger,
     });
     let results;
@@ -164,6 +170,7 @@ describe("Task Executor", function () {
   it("should run transfer file", async () => {
     executor = await TaskExecutor.create({
       package: "9a3b5d67b0b27746283cb5f287c13eab1beaa12d92a9f536b747c7ae",
+      payment: { network: "rinkeby " },
       logger,
     });
     const result = await executor.run(async (ctx) => {

--- a/tests/integration/tasks.spec.ts
+++ b/tests/integration/tasks.spec.ts
@@ -37,6 +37,7 @@ describe("Task Executor", function () {
   it("should run simple tasks by map function", async () => {
     executor = await TaskExecutor.create({
       package: "9a3b5d67b0b27746283cb5f287c13eab1beaa12d92a9f536b747c7ae",
+      payment: { network: "rinkeby" },
       logger,
     });
     const data = ["one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten"];

--- a/tests/integration/yacat.spec.ts
+++ b/tests/integration/yacat.spec.ts
@@ -23,6 +23,7 @@ describe("Password cracking", function () {
     const hash = "$P$5ZDzPE45CigTC6EY4cXbyJSLj/pGee0";
     executor = await TaskExecutor.create({
       package: "055911c811e56da4d75ffc928361a78ed13077933ffa8320fb1ec2db",
+      payment: { network: "rinkeby " },
       budget: 10,
       logger,
     });

--- a/tests/integration/yacat.spec.ts
+++ b/tests/integration/yacat.spec.ts
@@ -23,7 +23,7 @@ describe("Password cracking", function () {
     const hash = "$P$5ZDzPE45CigTC6EY4cXbyJSLj/pGee0";
     executor = await TaskExecutor.create({
       package: "055911c811e56da4d75ffc928361a78ed13077933ffa8320fb1ec2db",
-      payment: { network: "rinkeby " },
+      payment: { network: "rinkeby" },
       budget: 10,
       logger,
     });

--- a/tests/mock/entities/allocation.ts
+++ b/tests/mock/entities/allocation.ts
@@ -5,7 +5,7 @@ import { MarketDecoration } from "ya-ts-client/dist/ya-payment/index.js";
 // @ts-ignore
 export const allocationMock: Allocation = {
   timeout: "",
-  paymentPlatform: "erc20-rinkeby-tglm",
+  paymentPlatform: "erc20-goerli-tglm",
   address: "",
   id: "test_id",
   timestamp: "",
@@ -14,11 +14,11 @@ export const allocationMock: Allocation = {
     return Promise.resolve({
       properties: [
         {
-          key: "golem.com.payment.platform.erc20-rinkeby-tglm.address",
+          key: "golem.com.payment.platform.erc20-goerli-tglm.address",
           value: "0x19ee20338a4c4bf8f6aebc79d9d3af2a01434119",
         },
       ],
-      constraints: ["(golem.com.payment.platform.erc20-rinkeby-tglm.address=*)"],
+      constraints: ["(golem.com.payment.platform.erc20-goerli-tglm.address=*)"],
     });
   },
   async release(): Promise<void> {

--- a/tests/mock/fixtures/accounts.ts
+++ b/tests/mock/fixtures/accounts.ts
@@ -1,9 +1,9 @@
 export const accounts = [
   {
-    platform: "erc20-rinkeby-tglm",
+    platform: "erc20-goerli-tglm",
     address: "0x19ee20338a4c4bf8f6aebc79d9d3af2a01434119",
     driver: "erc20",
-    network: "rinkeby",
+    network: "goerli",
     token: "tGLM",
     send: true,
     receive: true,

--- a/tests/mock/fixtures/debit_notes.ts
+++ b/tests/mock/fixtures/debit_notes.ts
@@ -13,7 +13,7 @@ export const debitNotes = [
     recipientId: "0x19ee20338a4c4bf8f6aebc79d9d3af2a01434119",
     payeeAddr: "0xd9a4a6ba9e1800e4f61cd88dc23f082527f4ee28",
     payerAddr: "0x19ee20338a4c4bf8f6aebc79d9d3af2a01434119",
-    paymentPlatform: "erc20-rinkeby-tglm",
+    paymentPlatform: "erc20-goerli-tglm",
     timestamp: "2022-12-05T08:54:31.831Z",
     agreementId: "test_agreement_id",
     activityId: "00f36a80a8544260acbf4b09dc46f4fc",

--- a/tests/mock/fixtures/invoices.ts
+++ b/tests/mock/fixtures/invoices.ts
@@ -13,7 +13,7 @@ export const invoices = [
     recipientId: "0x19ee20338a4c4bf8f6aebc79d9d3af2a01434119",
     payeeAddr: "0xd9a4a6ba9e1800e4f61cd88dc23f082527f4ee28",
     payerAddr: "0x19ee20338a4c4bf8f6aebc79d9d3af2a01434119",
-    paymentPlatform: "erc20-rinkeby-tglm",
+    paymentPlatform: "erc20-goerli-tglm",
     timestamp: "2022-12-05T08:54:31.927Z",
     agreementId: "test_agreement_id",
     activityIds: ["00f36a80a8544260acbf4b09dc46f4fc"],

--- a/tests/unit/payment_service.test.ts
+++ b/tests/unit/payment_service.test.ts
@@ -23,8 +23,9 @@ describe("Payment Service", () => {
 
     it("should not creating allocations if there are no available accounts", async () => {
       const paymentService = new PaymentService({ payment: { network: "test2", driver: "test2" } });
-      const allocations = await paymentService.createAllocations();
-      expect(allocations.length).to.equal(0);
+      await expect(paymentService.createAllocations()).to.be.rejectedWith(
+        "Unable to create allocation for driver/network test2/test2. There is no requestor account supporting this platform."
+      );
       await paymentService.end();
     });
 

--- a/yajsapi/executor/config.ts
+++ b/yajsapi/executor/config.ts
@@ -8,7 +8,7 @@ const DEFAULTS = {
   subnetTag: "public",
   logLevel: "info",
   basePath: "http://127.0.0.1:7465",
-  payment: { driver: "erc20", network: "rinkeby" },
+  payment: { driver: "erc20", network: "goerli" },
   maxParallelTasks: 5,
   taskTimeout: 1000 * 60 * 3, // 3 min,
 };

--- a/yajsapi/payment/config.ts
+++ b/yajsapi/payment/config.ts
@@ -8,7 +8,7 @@ import { InvoiceOptions } from "./invoice.js";
 
 const DEFAULTS = {
   budget: 1.0,
-  payment: { driver: "erc20", network: "rinkeby" },
+  payment: { driver: "erc20", network: "goerli" },
   paymentTimeout: 20000,
   allocationExpires: 1000 * 60 * 30, // 30 min
   invoiceReceiveTimeout: 1000 * 60 * 5, // 5 min
@@ -107,5 +107,4 @@ export class InvoiceConfig extends BaseConfig {
   }
 }
 
-export class AccountConfig extends BaseConfig {
-}
+export class AccountConfig extends BaseConfig {}

--- a/yajsapi/payment/service.ts
+++ b/yajsapi/payment/service.ts
@@ -97,7 +97,7 @@ export class PaymentService {
     }
     if (!this.allocations.length) {
       throw new Error(
-        `Unable to create allocation for driver/network ${this.options.payment.driver}/${this.options.payment.network}`
+        `Unable to create allocation for driver/network ${this.options.payment.driver}/${this.options.payment.network}. There is no requestor account supporting this platform.`
       );
     }
     return this.allocations;

--- a/yajsapi/payment/service.ts
+++ b/yajsapi/payment/service.ts
@@ -95,6 +95,11 @@ export class PaymentService {
       }
       this.allocations.push(await Allocation.create({ ...this.options.options, account }));
     }
+    if (!this.allocations.length) {
+      throw new Error(
+        `Unable to create allocation for driver/network ${this.options.payment.driver}/${this.options.payment.network}`
+      );
+    }
     return this.allocations;
   }
 


### PR DESCRIPTION
Default payment updated to goerli. Maybe worth to mention that there are two config files with redundant payment config.  [yajsapi/executor/config.ts ](https://github.com/golemfactory/yajsapi/blob/master/yajsapi/executor/config.ts#L11) and [yajsapi/payment/config.ts](https://github.com/golemfactory/yajsapi/blob/master/yajsapi/payment/config.ts#L13) Also probably some check will fail as there are units that assumes to be run on rinkeby. 