### PR TITLE
Added missing tmp package (JST-77)

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "ip-num": "^1.4.1",
     "pino": "^8.11.0",
     "pino-pretty": "^10.0.1",
+    "tmp": "^0.2.1",
     "ya-ts-client": "^0.5.3"
   },
   "devDependencies": {


### PR DESCRIPTION
It’s weird.. because we have an integration test for this example:
https://github.com/golemfactory/yajsapi/blob/d7422f1fe6ef19188a44bde1e1176bd139658b75/tests/integration/tasks.spec.ts#L194

But normally everything works because the tmp package is installed also by cypress so when we install with yarn or npm everything works. The problem occurs when we install with the --production flag, then the tmp package is missing. I added a fix. It should now work with the --production flag as well.